### PR TITLE
[WIP] Fixed login button ID selector 

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ class EpicGamesClientLoginAdapter {
       await usernameOrEmailField.type(login, { delay: options.inputDelay });
       const passwordField = await page.waitForSelector('#password');
       await passwordField.type(credentials.password, { delay: options.inputDelay });
-      const loginButton = await page.waitForSelector('#login:not(:disabled)');
+      const loginButton = await page.waitForSelector('#sign-in:not(:disabled)');
       await loginButton.click();
     }
     await page.waitForResponse((response) => response.url() === 'https://www.epicgames.com/account/personal', {


### PR DESCRIPTION
# Background

Now epic game store change id for login button from `login` to `sign-in`

# Actual state
- Auth through browser not work

# Expected state
- Auth through browser work

# Test plan
1. Run https://github.com/Revadike/epicgames-freebies-claimer and disable normal auth
2. Check that auth through browser work correctly